### PR TITLE
Allow not sorting subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ When pointed at a group (or any other multi-command), `mkdocs-typer` will also g
 
 This allows you to generate documentation for an entire CLI application by pointing `mkdocs-typer` at the root command.
 
+Settings `sort` to `False` keeps the original definition order, which can be useful when documenting something that uses a particular order.
+
 ### Tweaking header levels
 
 By default, `mkdocs-typer` generates Markdown headers starting at `<h1>` for the root command section. This is generally what you want when the documentation should fill the entire page.
@@ -111,6 +113,7 @@ The syntax for `mkdocs-typer` blocks is the following:
     :module: <MODULE>
     :command: <COMMAND>
     :prog_name: <PROG_NAME>
+    :sort: <SORT>
     :depth: <DEPTH>
 ```
 
@@ -120,3 +123,4 @@ Options:
 - `command`: name of the command object.
 - `prog_name`: _(Optional, default: same as `command`)_ the name to display for the command.
 - `depth`: _(Optional, default: `0`)_ Offset to add when generating headers.
+- `sort`: _(Optional, default: `True`)_ Whether to sort commands or keep them in definition order.

--- a/mkdocs_typer/_docs.py
+++ b/mkdocs_typer/_docs.py
@@ -9,15 +9,15 @@ from typer.main import get_command
 from ._exceptions import MkDocsTyperException
 
 
-def make_command_docs(prog_name: str, command: typer.main.Typer, level: int = 0) -> Iterator[str]:
+def make_command_docs(prog_name: str, command: typer.main.Typer, level: int = 0, sort: bool = True) -> Iterator[str]:
     """Create the Markdown lines for a command and its sub-commands."""
     cmd = get_command(command)
-    for line in _recursively_make_command_docs(prog_name, cmd, level=level):
+    for line in _recursively_make_command_docs(prog_name, cmd, level=level, sort=sort):
         yield line.replace("\b", "")
 
 
 def _recursively_make_command_docs(
-    prog_name: str, command: click.Command, parent: typer.Context = None, level: int = 0
+    prog_name: str, command: click.Command, parent: typer.Context = None, level: int = 0, sort: bool = True
 ) -> Iterator[str]:
     """Create the raw Markdown lines for a command and its sub-commands."""
     ctx = typer.Context(command, parent=parent)
@@ -29,8 +29,10 @@ def _recursively_make_command_docs(
 
     subcommands = _get_sub_commands(ctx.command, ctx)
 
-    for command in sorted(subcommands, key=lambda cmd: cmd.name):
-        yield from _recursively_make_command_docs(command.name, command, parent=ctx, level=level + 1)
+    if sort:
+       subcommands = sorted(subcommands, key=lambda cmd: cmd.name)
+    for command in subcommands:
+        yield from _recursively_make_command_docs(command.name, command, parent=ctx, level=level + 1, sort=sort)
 
 
 def _get_sub_commands(command: click.Command, ctx: typer.Context) -> List[click.Command]:

--- a/mkdocs_typer/_docs.py
+++ b/mkdocs_typer/_docs.py
@@ -30,7 +30,7 @@ def _recursively_make_command_docs(
     subcommands = _get_sub_commands(ctx.command, ctx)
 
     if sort:
-       subcommands = sorted(subcommands, key=lambda cmd: cmd.name)
+        subcommands = sorted(subcommands, key=lambda cmd: cmd.name)
     for command in subcommands:
         yield from _recursively_make_command_docs(command.name, command, parent=ctx, level=level + 1, sort=sort)
 

--- a/mkdocs_typer/_extension.py
+++ b/mkdocs_typer/_extension.py
@@ -21,9 +21,17 @@ def replace_command_docs(**options: Any) -> Iterator[str]:
     prog_name = options.get("prog_name", command)
     depth = int(options.get("depth", 0))
 
+    sort_str = options.get("sort", "True")
+    if sort_str.lower() == "true":
+        sort = True
+    elif sort_str.lower() == "false":
+        sort = False
+    else:
+        raise MkDocsTyperException(f"{sort_str!r} is not a valid boolean. Expecting True or False.")
+
     command_obj = load_command(module, command)
 
-    return make_command_docs(prog_name=prog_name, command=command_obj, level=depth)
+    return make_command_docs(prog_name=prog_name, command=command_obj, level=depth, sort=sort)
 
 
 class TyperProcessor(Preprocessor):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,10 @@ twine
 wheel
 
 # Linters
-black==20.8b1
-flake8==3.8.4
-mypy==0.790
+black==22.6.0
+flake8==4.0.1
 
 # Testing
-mock==4.0.2
-pytest==5.4.3
-pytest-cov==2.10.1
+mock==4.0.3
+pytest==7.1.2
+pytest-cov==3.0.0

--- a/scripts/style
+++ b/scripts/style
@@ -7,4 +7,3 @@ set -x
 
 ${BIN}black --check --diff $FILES
 ${BIN}flake8 $FILES
-${BIN}mypy $FILES

--- a/tests/app/bar.py
+++ b/tests/app/bar.py
@@ -17,3 +17,11 @@ def hello(
     name: str = typer.Option(..., prompt="Your name", help="The person to greet."),
 ):
     """Simple program that greets NAME for a total of COUNT times."""
+
+
+@app.command()
+def goodbye(
+    count: int = typer.Option(default=1, help="Number of goodbyes.", show_default=False),
+    name: str = typer.Option(..., prompt="Your name", help="The person to greet."),
+):
+    """Simple program that says goodbye NAME for a total of COUNT times."""

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -18,6 +18,23 @@ Usage:
 cli bar [OPTIONS] COMMAND [ARGS]...
 ```
 
+### goodbye
+
+Simple program that says goodbye NAME for a total of COUNT times.
+
+Usage:
+
+```
+cli bar goodbye [OPTIONS]
+```
+
+Options:
+
+```
+  --count INTEGER  Number of goodbyes.
+  --name TEXT      The person to greet.  [required]
+```
+
 ### hello
 
 Simple program that greets NAME for a total of COUNT times.

--- a/tests/app/expected_unsorted.md
+++ b/tests/app/expected_unsorted.md
@@ -1,0 +1,61 @@
+# my_app
+
+Main entrypoint for this dummy program
+
+Usage:
+
+```
+cli [OPTIONS] COMMAND [ARGS]...
+```
+## foo
+
+Usage:
+
+```
+cli foo [OPTIONS]
+```
+
+## bar
+
+The bar command
+
+Usage:
+
+```
+cli bar [OPTIONS] COMMAND [ARGS]...
+```
+
+### hello
+
+Simple program that greets NAME for a total of COUNT times.
+
+Usage:
+
+```
+cli bar hello [OPTIONS]
+```
+
+Options:
+
+```
+  --count INTEGER  Number of greetings.
+  --name TEXT      The person to greet.  [required]
+```
+
+### goodbye
+
+Simple program that says goodbye NAME for a total of COUNT times.
+
+Usage:
+
+```
+cli bar goodbye [OPTIONS]
+```
+
+Options:
+
+```
+  --count INTEGER  Number of goodbyes.
+  --name TEXT      The person to greet.  [required]
+```
+

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -70,6 +70,41 @@ def test_depth():
     assert md.convert(source) == md.convert(expected)
 
 
+def test_sort_is_true_by_default():
+    """
+    The :sort: attribute allows the options to be displayed in the order they were defined in.
+    """
+    md = Markdown(extensions=[mkdocs_typer.makeExtension()])
+
+    source = dedent(
+        """
+        ::: mkdocs-typer
+            :module: tests.app.cli
+            :command: my_app
+            :sort: True
+        """
+    )
+    assert md.convert(source) == md.convert(EXPECTED)
+
+
+def test_sort():
+    """
+    The :sort: attribute allows the options to be displayed in the order they were defined in.
+    """
+    md = Markdown(extensions=[mkdocs_typer.makeExtension()])
+
+    source = dedent(
+        """
+        ::: mkdocs-typer
+            :module: tests.app.cli
+            :command: my_app
+            :sort: False
+        """
+    )
+    expected = (Path(__file__).parent / "app" / "expected_unsorted.md").read_text()
+    assert md.convert(source) == md.convert(expected)
+
+
 @pytest.mark.parametrize("option", ["module", "command"])
 def test_required_options(option):
     """

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -30,7 +30,7 @@ HELLO_EXPECTED = dedent(
     Options:
 
     ```
-      -d, --debug / --no-debug  Include debug output  [default: False]
+      -d, --debug / --no-debug  Include debug output  [default: no-debug]
     ```
 
     """

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -20,16 +20,8 @@ def goodbye(debug: bool = typer.Option(False, "--debug/--no-debug", "-d", help="
     """Goodbye, world!"""
 
 
-HELLO_EXPECTED = dedent(
+GOODBYE_DOCS = dedent(
     """
-    # hello
-
-    Usage:
-
-    ```
-     [OPTIONS] COMMAND [ARGS]...
-    ```
-
     ## goodbye
 
     Goodbye, world!
@@ -45,7 +37,12 @@ HELLO_EXPECTED = dedent(
     ```
       -d, --debug / --no-debug  Include debug output  [default: no-debug]
     ```
+    """
+).strip()
 
+
+HELLO_DOCS = dedent(
+    """
     ## hello
 
     Hello, world!
@@ -61,9 +58,28 @@ HELLO_EXPECTED = dedent(
     ```
       -d, --debug / --no-debug  Include debug output  [default: no-debug]
     ```
-
     """
 ).strip()
+
+
+EXPECTED_FORMAT = dedent(
+    """
+    # hello
+
+    Usage:
+
+    ```
+     [OPTIONS] COMMAND [ARGS]...
+    ```
+
+    {first}
+
+    {second}
+    """
+).strip()
+
+
+HELLO_EXPECTED = EXPECTED_FORMAT.format(first=GOODBYE_DOCS, second=HELLO_DOCS)
 
 
 def test_make_command_docs():
@@ -79,3 +95,4 @@ def test_depth():
 def test_prog_name():
     output = "\n".join(make_command_docs("hello-world", app)).strip()
     assert output == HELLO_EXPECTED.replace("# hello", "# hello-world", 1)
+

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -96,3 +96,7 @@ def test_prog_name():
     output = "\n".join(make_command_docs("hello-world", app)).strip()
     assert output == HELLO_EXPECTED.replace("# hello", "# hello-world", 1)
 
+
+def test_no_sorting():
+    output = "\n".join(make_command_docs("hello", app, sort=False)).strip()
+    assert output == EXPECTED_FORMAT.format(first=HELLO_DOCS, second=GOODBYE_DOCS)

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -15,16 +15,45 @@ def hello(debug: bool = typer.Option(False, "--debug/--no-debug", "-d", help="In
     """Hello, world!"""
 
 
+@app.command()
+def goodbye(debug: bool = typer.Option(False, "--debug/--no-debug", "-d", help="Include debug output")):
+    """Goodbye, world!"""
+
+
 HELLO_EXPECTED = dedent(
     """
     # hello
+
+    Usage:
+
+    ```
+     [OPTIONS] COMMAND [ARGS]...
+    ```
+
+    ## goodbye
+
+    Goodbye, world!
+
+    Usage:
+
+    ```
+     goodbye [OPTIONS]
+    ```
+
+    Options:
+
+    ```
+      -d, --debug / --no-debug  Include debug output  [default: no-debug]
+    ```
+
+    ## hello
 
     Hello, world!
 
     Usage:
 
     ```
-    hello [OPTIONS]
+     hello [OPTIONS]
     ```
 
     Options:
@@ -49,4 +78,4 @@ def test_depth():
 
 def test_prog_name():
     output = "\n".join(make_command_docs("hello-world", app)).strip()
-    assert output == HELLO_EXPECTED.replace("# hello", "# hello-world")
+    assert output == HELLO_EXPECTED.replace("# hello", "# hello-world", 1)


### PR DESCRIPTION
Hi!

By default, subcommands are sorted alphabetically, but I needed to make it such that they could be sorted by definition order. This is a PR for that.

I updated pytest etc to be compatible with 3.10, and removed mypy because it was failing before I had made any changes.